### PR TITLE
List caches are now stored under the cluster id rather than node id (…

### DIFF
--- a/src/re_wm_bucket.erl
+++ b/src/re_wm_bucket.erl
@@ -22,7 +22,7 @@
 -export([resources/0, routes/0, dispatch/0]).
 -export([init/1]).
 -export([service_available/2,
-         allowed_methods/2, 
+         allowed_methods/2,
          content_types_provided/2,
          content_types_accepted/2,
          resource_exists/2,
@@ -53,7 +53,7 @@
 %%% API
 %%%===================================================================
 
-resources() -> 
+resources() ->
     [{jobs, [riak_explorer, jobs_for_resource]}].
 
 routes() ->
@@ -136,16 +136,16 @@ resource_exists(RD, Ctx=?bucketResource(BucketType, Bucket, Resource)) ->
     Node = Ctx#ctx.node,
     Id = list_to_atom(Resource),
     case proplists:get_value(Id, resources()) of
-        [M,F] -> 
+        [M,F] ->
             Response = M:F(Node, BucketType, Bucket),
             {true, RD, Ctx#ctx{id=Id, response=Response}};
-        _ -> 
+        _ ->
             {false, RD, Ctx}
     end;
 resource_exists(RD, Ctx) ->
     {false, RD, Ctx}.
 
-delete_resource(RD, Ctx) -> 
+delete_resource(RD, Ctx) ->
     {true, RD, Ctx}.
 
 accept_content(RD, Ctx=?putBuckets(BucketType)) ->
@@ -178,7 +178,7 @@ provide_jsonapi_content(RD, Ctx=#ctx{id=Id, response=[{Type, Objects}]}) ->
 node_from_context(Ctx) ->
     case Ctx of
         #ctx{cluster=undefined, node=N} -> list_to_atom(N);
-        #ctx{cluster=C} -> re_riak:first_node(C)
+        #ctx{cluster=C} -> re_riak:first_node(list_to_atom(C))
     end.
 
 render_json(Data, RD, Ctx) ->

--- a/src/re_wm_bucket_type.erl
+++ b/src/re_wm_bucket_type.erl
@@ -22,7 +22,7 @@
 -export([resources/0, routes/0, dispatch/0]).
 -export([init/1]).
 -export([service_available/2,
-         allowed_methods/2, 
+         allowed_methods/2,
          content_types_provided/2,
          resource_exists/2,
          provide_jsonapi_content/2,
@@ -46,7 +46,7 @@
 %%% API
 %%%===================================================================
 
-resources() -> 
+resources() ->
     [{jobs, [riak_explorer, jobs_for_resource]}].
 
 routes() ->
@@ -105,10 +105,10 @@ resource_exists(RD, Ctx=?bucketTypeResource(BucketType, Resource)) ->
     Node = Ctx#ctx.node,
     Id = list_to_atom(Resource),
     case proplists:get_value(Id, resources()) of
-        [M,F] -> 
+        [M,F] ->
             Response = M:F(Node, BucketType),
             {true, RD, Ctx#ctx{id=Id, response=Response}};
-        _ -> 
+        _ ->
             {false, RD, Ctx}
     end;
 resource_exists(RD, Ctx) ->
@@ -137,7 +137,7 @@ provide_jsonapi_content(RD, Ctx=#ctx{id=Id, response=[{Type, Objects}]}) ->
 node_from_context(Ctx) ->
     case Ctx of
         #ctx{cluster=undefined, node=N} -> list_to_atom(N);
-        #ctx{cluster=C} -> re_riak:first_node(C)
+        #ctx{cluster=C} -> re_riak:first_node(list_to_atom(C))
     end.
 
 render_json(Data, RD, Ctx) ->

--- a/src/re_wm_control.erl
+++ b/src/re_wm_control.erl
@@ -179,7 +179,7 @@ maybe_atomize(Data) when is_atom(Data) -> Data.
 node_from_context(Ctx) ->
     case Ctx of
         #ctx{cluster=undefined, node=N} -> list_to_atom(N);
-        #ctx{cluster=C} -> re_riak:first_node(C)
+        #ctx{cluster=C} -> re_riak:first_node(list_to_atom(C))
     end.
 
 render_json(Data, RD, Ctx) ->

--- a/src/re_wm_key.erl
+++ b/src/re_wm_key.erl
@@ -22,7 +22,7 @@
 -export([resources/0, routes/0, dispatch/0]).
 -export([init/1]).
 -export([service_available/2,
-         allowed_methods/2, 
+         allowed_methods/2,
          content_types_provided/2,
          content_types_accepted/2,
          resource_exists/2,
@@ -53,7 +53,7 @@
 %%% API
 %%%===================================================================
 
-resources() -> 
+resources() ->
     [].
 
 routes() ->
@@ -128,16 +128,16 @@ resource_exists(RD, Ctx=?keyResource(BucketType, Bucket, Key, Resource)) ->
     Node = Ctx#ctx.node,
     Id = list_to_atom(Resource),
     case proplists:get_value(Id, resources()) of
-        [M,F] -> 
+        [M,F] ->
             Response = M:F(Node, BucketType, Bucket, Key),
             {true, RD, Ctx#ctx{id=Id, response=Response}};
-        _ -> 
+        _ ->
             {false, RD, Ctx}
     end;
 resource_exists(RD, Ctx) ->
     {false, RD, Ctx}.
 
-delete_resource(RD, Ctx) -> 
+delete_resource(RD, Ctx) ->
     {true, RD, Ctx}.
 
 accept_content(RD, Ctx=?putKeys(BucketType, Bucket)) ->
@@ -170,7 +170,7 @@ provide_jsonapi_content(RD, Ctx=#ctx{id=Id, response=[{Type, Objects}]}) ->
 node_from_context(Ctx) ->
     case Ctx of
         #ctx{cluster=undefined, node=N} -> list_to_atom(N);
-        #ctx{cluster=C} -> re_riak:first_node(C)
+        #ctx{cluster=C} -> re_riak:first_node(list_to_atom(C))
     end.
 
 render_json(Data, RD, Ctx) ->

--- a/src/re_wm_riak_proxy.erl
+++ b/src/re_wm_riak_proxy.erl
@@ -32,7 +32,7 @@
 %%% API
 %%%===================================================================
 
-resources() -> 
+resources() ->
     [].
 
 routes() ->
@@ -94,14 +94,14 @@ service_available(RD, Ctx0) ->
 node_from_context(Ctx) ->
     case Ctx of
         #ctx{cluster=undefined, node=N} -> list_to_atom(N);
-        #ctx{cluster=C} -> re_riak:first_node(C)
+        #ctx{cluster=C} -> re_riak:first_node(list_to_atom(C))
     end.
 
 clean_request_headers(Headers) ->
     [{K,V} || {K,V} <- Headers,
-              K /= 'Host', 
-              K /= 'Content-Length', 
-              K /= 'X-Requested-With', 
+              K /= 'Host',
+              K /= 'Content-Length',
+              K /= 'X-Requested-With',
               K /= 'Referer'].
 
 wm_to_ibrowse_method(Method) when is_list(Method) ->


### PR DESCRIPTION
…REX-54)

Also standardized on atom type for referring to clusters in re_riak module.
