### PR TITLE
Replacing rpc:call with safe_rpc

### DIFF
--- a/src/re_riak.erl
+++ b/src/re_riak.erl
@@ -440,7 +440,7 @@ maybe_load_patch(Node, _) ->
         _ -> ok
     end.
 
-remote(N,M,F,A) ->
+remote(N, M, F, A) ->
     safe_rpc(N, M, F, A, 60000).
 
 safe_rpc(Node, Module, Function, Args, Timeout) ->


### PR DESCRIPTION
Per suggestions, adding try/catch wrapper around rpc:call to prevent repeated supervisor restarts of worker running rpc calls:

```
remote(N, M, F, A) ->
    safe_rpc(N, M, F, A, 60000).

safe_rpc(Node, Module, Function, Args, Timeout) ->
    try rpc:call(Node, Module, Function, Args, Timeout) of
        Result ->
            Result
    catch
        'EXIT':{noproc, _NoProcDetails} ->
            {badrpc, rpc_process_down}
    end.
```
