### PR TITLE
Add support for the "transfer" admin command.

### DIFF
--- a/src/re_wm_control.erl
+++ b/src/re_wm_control.erl
@@ -64,6 +64,7 @@ routes() ->
     CClear         = Cluster ++ ["clear"],
     CStatus        = Cluster ++ ["status"],
     CRingReady     = Cluster ++ ["ringready"],
+    CTransfers     = Cluster ++ ["transfers"],
 
     Nodes         = Base ++ ["nodes"],
     Node          = Nodes ++ [node],
@@ -82,11 +83,12 @@ routes() ->
     Clear         = Node ++ ["clear"],
     Status        = Node ++ ["status"],
     RingReady     = Node ++ ["ringready"],
+    Transfers     = Node ++ ["transfers"],
 
     [CRepair, CJoin,CLeave2,CSJoin,CSLeave,CSLeave2,CForceRemove,CReplace,CSReplace,
-     CForceReplace,CPlan,CCommit,CClear,CStatus,CRingReady] ++
+     CForceReplace,CPlan,CCommit,CClear,CStatus,CRingReady,CTransfers] ++
     [Repair, Join,Leave2,SJoin,SLeave,SLeave2,ForceRemove,Replace,SReplace,
-     ForceReplace,Plan,Commit,Clear,Status,RingReady].
+     ForceReplace,Plan,Commit,Clear,Status,RingReady,Transfers].
 
 dispatch() -> lists:map(fun(Route) -> {Route, ?MODULE, []} end, routes()).
 
@@ -133,6 +135,8 @@ resource_exists(RD, Ctx=?command(Command)) ->
             {true, re_riak:status(Node)};
         "ringready" ->
             {true, re_riak:ringready(Node)};
+        "transfers" ->
+            {true, re_riak:transfers(Node)};
         _ -> {false, undefined}
     end,
     {Exists, RD, Ctx#ctx{id=list_to_atom(Command), response=Response}};


### PR DESCRIPTION
Added at the following endpoints:
/control/nodes/$node/transfers
/control/clusters/$cluster/transfers

Sample output:
```
{"transfers":{"down":[],"waiting_to_handoff":{"dev2@127.0.0.1":64,"dev3@127.0.0.1":64,"dev4@127.0.0.1":64,"dev5@127.0.0.1":64},"stopped":[],"active":[{"src_node":"dev1@127.0.0.1","target_node":"dev2@127.0.0.1","type":"ownership","mod":"riak_kv_vnode","target_partition":22835963083295358096932575511191922182123945984,"start_ts":"2015-10-28 23:23:45","stats":["no_stats"]},{"src_node":"dev1@127.0.0.1","target_node":"dev3@127.0.0.1","type":"ownership","mod":"riak_kv_vnode","target_partition":45671926166590716193865151022383844364247891968,"start_ts":"2015-10-28 23:23:45","stats":["no_stats"]}]},"links":{"self":"/control/clusters/default/transfers"}}
```