### PR TITLE
Fill in props for a specific bucket_type.

### DIFF
--- a/src/re_wm_bucket_type.erl
+++ b/src/re_wm_bucket_type.erl
@@ -111,7 +111,11 @@ resource_exists(RD, Ctx=?createBucketType(_)) ->
     {true, RD, Ctx};
 resource_exists(RD, Ctx=?bucketTypeInfo(BucketType)) ->
     Id = list_to_binary(BucketType),
-    Response = [{bucket_types, [{id,Id}, {props, []}]}],
+    Node = Ctx#ctx.node,
+    Props = lists:flatten([proplists:get_value(props, Prop) ||
+                              Prop <- proplists:get_value(bucket_types, re_riak:bucket_types(Node)),
+                              Id =:= proplists:get_value(name, Prop)]),
+    Response = [{bucket_types, [{id,Id}, {props, Props}]}],
     {true, RD, Ctx#ctx{id=bucket_type, response=Response}};
 resource_exists(RD, Ctx=?bucketTypeResource(BucketType, Resource)) ->
     Node = Ctx#ctx.node,


### PR DESCRIPTION
In the endpoint /explore/clusters/default/bucket_types/$bucket_type/,
return the properties of the bucket type instead of a hard-coded empty
list.

Example output, from hitting `/explore/clusters/default/bucket_types/default/`
```
{"bucket_type":{"id":"default","props":{"active":true,"allow_mult":false,"basic_quorum":false,"big_vclock":50,"chash_keyfun":"{riak_core_util,chash_std_keyfun}","dvv_enabled":false,"dw":"quorum","last_write_wins":false,"linkfun":"{modfun,riak_kv_wm_link_walker,mapreduce_linkfun}","n_val":3,"notfound_ok":true,"old_vclock":86400,"postcommit":[],"pr":0,"precommit":[],"pw":0,"r":"quorum","rw":"quorum","small_vclock":50,"w":"quorum","write_once":false,"young_vclock":20}},"links":{"self":"/explore/clusters/default/bucket_types/default/"}}
```