### PR TITLE
Support the /explore/nodes/$node/config endpoint.

### DIFF
--- a/src/re_riak.erl
+++ b/src/re_riak.erl
@@ -91,6 +91,7 @@
          clusters/0,
          cluster/1,
          first_node/1,
+         node_config/2,
          nodes/1,
          node_exists/2]).
 
@@ -754,6 +755,15 @@ nodes(Cluster) ->
             WithIds = lists:map(fun(N) -> [{id, N}] end, Nodes),
             [{nodes, WithIds}];
         _ -> [{nodes, []}]
+    end.
+
+node_config(_, Node) ->
+    load_patch(Node),
+    case remote(Node, re_riak_patch, effective_config, []) of
+        {error, legacy_config} ->
+            [{error, not_found, [{error, <<"Legacy configuration files found, effective config not available.">>}]}];
+        Config ->
+            [{config, Config}]
     end.
 
 node_exists(Cluster, Node) ->


### PR DESCRIPTION
This returns the equivalent of calling `riak config effective`.  This is
also available at the following endpoint:

/explore/clusters/$cluster/nodes/$node/config

Since this involves a lot of calls to Cuttlefish on the Riak node, this
is implemented using the a Riak patch.

Fixes #95.

Sample output with the presence of riak.conf and advanced.config:
```JSON
{"config":{"config":{"vnode_management_timer":"10s","transfer_limit":"2","tls_protocols.tlsv1.2":"on","tls_protocols.tlsv1.1":"off","tls_protocols.tlsv1":"off","tls_protocols.sslv3":"off","strong_consistency":"off","storage_backend":"bitcask","snmp.traps.replication":"off","snmp.refresh_frequency":"1m","snmp.nodePutTimeMedianThreshold":"off","snmp.nodePutTimeMeanThreshold":"off","snmp.nodePutTime99Threshold":"off","snmp.nodePutTime95Threshold":"off","snmp.nodePutTime100Threshold":"off","snmp.nodeGetTimeMedianThreshold":"off","snmp.nodeGetTimeMeanThreshold":"off","snmp.nodeGetTime99Threshold":"off","snmp.nodeGetTime95Threshold":"off","snmp.nodeGetTime100Threshold":"off","snmp.force_reload":"on","snmp.database_dir":"/var/lib/riak/snmp/agent/db","secure_referer_check":"on","search.solr.start_timeout":"30s","search.solr.port":"8093","search.solr.jvm_options":"-d64 -Xms1g -Xmx1g -XX:+UseStringCache -XX:+UseCompressedOops","search.solr.jmx_port":"8985","search.root_dir":"$(platform_data_dir)/yz","search.anti_entropy.data_dir":"$(platform_data_dir)/yz_anti_entropy","search":"off","sasl":"off","runtime_health.triggers.process.long_schedule":"off","runtime_health.triggers.process.heap_size":"160444000","runtime_health.triggers.process.garbage_collection":"off","runtime_health.triggers.port":"on","runtime_health.triggers.distribution_port":"on","runtime_health.thresholds.busy_processes":"30","runtime_health.thresholds.busy_ports":"2","ring_size":"64","ring.state_dir":"$(platform_data_dir)/ring","riak_control.auth.mode":"off","riak_control":"off","retry_put_coordinator_failure":"on","protobuf.nagle":"off","protobuf.backlog":"128","platform_log_dir":"/var/log/riak","platform_lib_dir":"/usr/lib/riak/lib","platform_etc_dir":"/etc/riak","platform_data_dir":"/var/lib/riak","platform_bin_dir":"/usr/sbin","object.size.warning_threshold":"5MB","object.size.maximum":"50MB","object.siblings.warning_threshold":"25","object.siblings.maximum":"100","object.format":"1","nodename":"riak@127.0.0.1","metadata_cache_size":"off","max_concurrent_requests":"50000","log.syslog.level":"info","log.syslog.ident":"riak","log.syslog.facility":"daemon","log.syslog":"off","log.error.redirect":"on","log.error.messages_per_second":"100","log.error.file":"$(platform_log_dir)/error.log","log.crash.size":"10MB","log.crash.rotation.keep":"5","log.crash.rotation":"$D0","log.crash.maximum_message_size":"64KB","log.crash.file":"$(platform_log_dir)/crash.log","log.crash":"on","log.console.level":"info","log.console.file":"$(platform_log_dir)/console.log","log.console":"file","listener.protobuf.internal":"127.0.0.1:8087","listener.http.internal":"127.0.0.1:8098","leveldb.write_buffer_size_min":"30MB","leveldb.write_buffer_size_max":"60MB","leveldb.verify_compaction":"on","leveldb.verify_checksums":"on","leveldb.tiered":"off","leveldb.threads":"71","leveldb.sync_on_write":"off","leveldb.maximum_memory.percent":"70","leveldb.limited_developer_mem":"off","leveldb.fadvise_willneed":"false","leveldb.data_root":"$(platform_data_dir)/leveldb","leveldb.compression":"on","leveldb.compaction.trigger.tombstone_count":"1000","leveldb.bloomfilter":"on","leveldb.block_cache_threshold":"32MB","leveldb.block.size_steps":"16","leveldb.block.size":"4KB","leveldb.block.restart_interval":"16","jmx.restart_check":"10m","jmx.refresh_rate":"30s","jmx.port":"41110","jmx":"off","javascript.reduce_pool_size":"6","javascript.maximum_stack_size":"16MB","javascript.maximum_heap_size":"8MB","javascript.map_pool_size":"8","javascript.hook_pool_size":"2","honor_cipher_order":"on","handoff.use_background_manager":"off","handoff.port":"8099","handoff.outbound":"on","handoff.max_rejects":"6","handoff.ip":"0.0.0.0","handoff.inbound":"on","erlang.smp":"enable","erlang.schedulers.force_wakeup_interval":"500","erlang.schedulers.compaction_of_load":"false","erlang.process_limit":"256000","erlang.max_ports":"65536","erlang.max_ets_tables":"256000","erlang.fullsweep_after":"0","erlang.distribution_buffer_size":"32MB","erlang.crash_dump":"/var/log/riak/erl_crash.dump","erlang.async_threads":"64","erlang.W":"w","erlang.K":"on","dtrace":"off","distributed_cookie":"riak","datatypes.compression_level":"1","check_crl":"on","buckets.default.w":"quorum","buckets.default.rw":"quorum","buckets.default.r":"quorum","buckets.default.pw":"0","buckets.default.pr":"0","buckets.default.notfound_ok":"true","buckets.default.n_val":"3","buckets.default.merge_strategy":"1","buckets.default.last_write_wins":"false","buckets.default.dw":"quorum","buckets.default.basic_quorum":"false","buckets.default.allow_mult":"false","bitcask.sync.strategy":"none","bitcask.open_timeout":"4s","bitcask.merge_check_jitter":"30%","bitcask.merge_check_interval":"3m","bitcask.merge.window.start":"0","bitcask.merge.window.end":"23","bitcask.merge.triggers.fragmentation":"60","bitcask.merge.triggers.dead_bytes":"512MB","bitcask.merge.thresholds.small_file":"10MB","bitcask.merge.thresholds.fragmentation":"40","bitcask.merge.thresholds.dead_bytes":"128MB","bitcask.merge.policy":"always","bitcask.max_merge_size":"100GB","bitcask.max_file_size":"2GB","bitcask.io_mode":"erlang","bitcask.hintfile_checksums":"strict","bitcask.fold.max_puts":"0","bitcask.fold.max_age":"unlimited","bitcask.expiry.grace_time":"0","bitcask.expiry":"off","bitcask.data_root":"$(platform_data_dir)/bitcask","background_manager":"off","anti_entropy.write_buffer_size":"4MB","anti_entropy.use_background_manager":"off","anti_entropy.trigger_interval":"15s","anti_entropy.tree.expiry":"1w","anti_entropy.tree.build_limit.per_timespan":"1h","anti_entropy.tree.build_limit.number":"1","anti_entropy.throttle":"on","anti_entropy.max_open_files":"20","anti_entropy.data_dir":"$(platform_data_dir)/anti_entropy","anti_entropy.concurrency_limit":"2","anti_entropy.bloomfilter":"on","anti_entropy":"active"},"advanced_config":["{riak_core,[{cluster_mgr,{\"0.0.0.0\",9080}}]}","{riak_repl,[{data_root,\"/var/lib/riak/riak_repl/\"},\n            {max_fssource_cluster,5},\n            {max_fssource_node,1},\n            {max_fssink_node,1},\n            {fullsync_on_connect,true},\n            {fullsync_interval,30},\n            {rtq_max_bytes,104857600},\n            {proxy_get,disabled},\n            {rt_heartbeat_interval,15},\n            {rt_heartbeat_timeout,15},\n            {fullsync_use_background_manager,true}]}"]},"links":{"self":"/explore/nodes/riak@127.0.0.1/config"}}
```

Sample output when app.config and/or vm.args exist:
```JSON
{"error":"Legacy configuration files found, effective config not available."}
```