### PR TITLE
Fix /explore/clusters/$cluster/nodes/$node endpoint

### DIFF
--- a/src/re_riak.erl
+++ b/src/re_riak.erl
@@ -768,7 +768,8 @@ node_config(_, Node) ->
     end.
 
 node_props(Node) ->
-    [{riak_type, riak_type_for_node(Node)}].
+    [{id, Node},
+     {riak_type, riak_type_for_node(Node)}].
 
 node_exists(Cluster, Node) ->
     Filter = lists:filter(fun(X) ->

--- a/src/re_riak.erl
+++ b/src/re_riak.erl
@@ -92,6 +92,7 @@
          cluster/1,
          first_node/1,
          node_config/2,
+         node_props/1,
          nodes/1,
          node_exists/2]).
 
@@ -766,11 +767,14 @@ node_config(_, Node) ->
             [{config, Config}]
     end.
 
+node_props(Node) ->
+    [{riak_type, riak_type_for_node(Node)}].
+
 node_exists(Cluster, Node) ->
     Filter = lists:filter(fun(X) ->
         case X of
             {error, not_found} -> false;
-            [{id, Node}] -> true;
+            {nodes, [[{id, Node}]]} -> true;
             _ -> false
         end end, nodes(Cluster)),
     case length(Filter) of

--- a/src/re_wm_node.erl
+++ b/src/re_wm_node.erl
@@ -101,8 +101,11 @@ resource_exists(RD, Ctx=?nodeInfo(Cluster0, Node)) ->
     end,
     case re_riak:node_exists(Cluster, Node) of
         true ->
-            Id = list_to_binary(Node),
-            Response = [{nodes, [{id,Id}, {props, []}]}],
+            Id = case Node of
+                     S when is_list(S) -> list_to_binary(S);
+                     _ -> Node
+                 end,
+            Response = [{nodes, [{id,Id}, {props, re_riak:node_props(Node)}]}],
             {true, RD, Ctx#ctx{id=node, response=Response}};
         false ->
             {false, RD, Ctx}


### PR DESCRIPTION
Fix node_exists/2 so it will match on what is returned from nodes/1.

Also add `riak_version` to the `props` returned by the $node endpoint.

Fixes #110.