### PR TITLE
Change restart behavior to temporary for explorer spec

### DIFF
--- a/src/riak_control_sup.erl
+++ b/src/riak_control_sup.erl
@@ -53,7 +53,7 @@ init([]) ->
                          [riak_control_session]},
     ExplorerSpec = {riak_explorer,
                     {riak_explorer, start, [[]]},
-                    permanent, 5000, worker, [riak_explorer]},
+                    temporary, 5000, worker, [riak_explorer]},
 
     %% determine if riak_control is enabled or not
     case app_helper:get_env(riak_control, enabled, false) of


### PR DESCRIPTION
When starting Riak Explorer within the Riak supervision tree, this change makes it so that restarts are never attempted on the riak explorer application. 

This should address #144

It should be noted that the webmachine endoints should all still work even if the explorer app is not restarted. The only thing that will stop working is the jobs manager that handles things like list keys, etc.