### PR TITLE
Configurable patch path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ configure.sh
 .vagrant
 packages
 oauth.txt
+rel/sandbox

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ PATCH_PKGNAME         ?= $(REPO)-$(PATCH_PKG_VERSION)-$(OS_FAMILY)-$(OS_VERSION)
 PATCH_DEPLOY_BASE     ?= "https://uploads.github.com/repos/basho-labs/$(REPO)/releases/$(RELEASE_ID)/assets?access_token=$(OAUTH_TOKEN)&name=$(PATCH_PKGNAME)"
 PATCH_DOWNLOAD_BASE   ?= https://github.com/basho-labs/$(REPO)/releases/download/$(GIT_TAG)/$(PATCH_PKGNAME)
 
-reltarball: RIAK_BASE = rel
+reltarball: RIAK_BASE = .
 reltarball: PATCH_PKG_VERSION = $(PKG_VERSION).relpatch
 reltarball: tarball
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ recompile:
 	$(REBAR) compile skip_deps=true
 deps:
 	$(REBAR) get-deps
-clean: cleantest relclean
+clean: cleantest relclean clean-sandbox
 	-rm -rf packages
 clean-sandbox:
 	-rm -rf rel/sandbox

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,10 @@ PATCH_PKGNAME         ?= $(REPO)-$(PATCH_PKG_VERSION)-$(OS_FAMILY)-$(OS_VERSION)
 PATCH_DEPLOY_BASE     ?= "https://uploads.github.com/repos/basho-labs/$(REPO)/releases/$(RELEASE_ID)/assets?access_token=$(OAUTH_TOKEN)&name=$(PATCH_PKGNAME)"
 PATCH_DOWNLOAD_BASE   ?= https://github.com/basho-labs/$(REPO)/releases/download/$(GIT_TAG)/$(PATCH_PKGNAME)
 
+reltarball: RIAK_BASE = rel
+reltarball: PATCH_PKG_VERSION = $(PKG_VERSION).relpatch
+reltarball: tarball
+
 tarball: compile
 	echo "Creating packages/"$(PATCH_PKGNAME)
 	-rm -rf rel/sandbox/$(RIAK_BASE)

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ deps:
 	$(REBAR) get-deps
 clean: cleantest relclean
 	-rm -rf packages
+	-rm -rf rel/sandbox
 cleantest:
 	rm -rf .eunit/*
 test: cleantest
@@ -97,16 +98,16 @@ PATCH_DOWNLOAD_BASE   ?= https://github.com/basho-labs/$(REPO)/releases/download
 
 tarball: compile
 	echo "Creating packages/"$(PATCH_PKGNAME)
-	-rm -rf rel/$(RIAK_BASE)
-	mkdir -p rel/$(RIAK_BASE)/riak/lib/basho-patches
-	mkdir -p rel/$(RIAK_BASE)/riak/priv
-	cp -R deps/riakc/ebin/* rel/$(RIAK_BASE)/riak/lib/basho-patches/
-	cp -R deps/riak_pb/ebin/* rel/$(RIAK_BASE)/riak/lib/basho-patches/
-	cp -R deps/protobuffs/ebin/* rel/$(RIAK_BASE)/riak/lib/basho-patches/
-	cp -R ebin/* rel/$(RIAK_BASE)/riak/lib/basho-patches/
-	cp -R priv/* rel/$(RIAK_BASE)/riak/priv/
+	-rm -rf rel/sandbox/$(RIAK_BASE)
+	mkdir -p rel/sandbox/$(RIAK_BASE)/riak/lib/basho-patches
+	mkdir -p rel/sandbox/$(RIAK_BASE)/riak/priv
+	cp -R deps/riakc/ebin/* rel/sandbox/$(RIAK_BASE)/riak/lib/basho-patches/
+	cp -R deps/riak_pb/ebin/* rel/sandbox/$(RIAK_BASE)/riak/lib/basho-patches/
+	cp -R deps/protobuffs/ebin/* rel/sandbox/$(RIAK_BASE)/riak/lib/basho-patches/
+	cp -R ebin/* rel/sandbox/$(RIAK_BASE)/riak/lib/basho-patches/
+	cp -R priv/* rel/sandbox/$(RIAK_BASE)/riak/priv/
 	mkdir -p packages
-	tar -C rel -czf $(PATCH_PKGNAME) root
+	tar -C rel/sandbox -czf $(PATCH_PKGNAME) $(RIAK_BASE)
 	mv $(PATCH_PKGNAME) packages/
 	cd packages && $(SHASUM) $(PATCH_PKGNAME) > $(PATCH_PKGNAME).sha
 	cd packages && echo "$(PATCH_DOWNLOAD_BASE)" > remote.txt


### PR DESCRIPTION
This adds a target to build a second `patch` archive, with no parent dir, compatible with the official `rel` builds